### PR TITLE
Fix: map render error should reject promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,13 @@ class Map {
   }) {
     return new Promise((resolve) => {
       if (accessToken) mapboxgl.accessToken = accessToken
+      this.map.once('idle', () => {
+        // @ts-ignore
+        window.devicePixelRatio = originalPixelRatio
+        this.map.getCanvas().toBlob((blob) => {
+          resolve(blob)
+        })
+      })
       if (style) this.setStyle(style)
       this.mapDiv.style.width = width + 'px'
       this.mapDiv.style.height = height + 'px'
@@ -54,13 +61,6 @@ class Map {
       window.devicePixelRatio = pixelRatio
       this.map.resize()
       this.map.jumpTo({ center, zoom })
-      this.map.on('idle', () => {
-        // @ts-ignore
-        window.devicePixelRatio = originalPixelRatio
-        this.map.getCanvas().toBlob((blob) => {
-          resolve(blob)
-        })
-      })
     })
   }
 }

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ class Map {
     zoom,
     pixelRatio
   }) {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       if (accessToken) mapboxgl.accessToken = accessToken
       this.map.once('error', reject)
       this.map.once('idle', () => {

--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ class Map {
   }) {
     return new Promise((resolve) => {
       if (accessToken) mapboxgl.accessToken = accessToken
+      this.map.once('error', reject)
       this.map.once('idle', () => {
         // @ts-ignore
         window.devicePixelRatio = originalPixelRatio


### PR DESCRIPTION
If the map render was failing (e.g. could not load map assets) then the promise would never resolve